### PR TITLE
[DOR-438][AO] support data URLs

### DIFF
--- a/app/uk/gov/hmrc/traderservices/models/FileTransferRequest.scala
+++ b/app/uk/gov/hmrc/traderservices/models/FileTransferRequest.scala
@@ -21,6 +21,7 @@ import play.api.libs.json.Format
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.HttpRequest
 import scala.util.Try
+import java.net.URL
 
 case class FileTransferRequest(
   conversationId: String,
@@ -44,6 +45,9 @@ case class FileTransferRequest(
   lazy val endTime: Long = System.nanoTime()
   def durationMillis: Int =
     ((endTime - startTime) / 1000000).toInt
+
+  def isDataURL: Boolean =
+    downloadUrl.startsWith("data:")
 }
 
 object FileTransferRequest {
@@ -87,8 +91,8 @@ object FileTransferRequest {
 
   final val downloadUrlValidator: Validate[String] =
     check(
-      uri => Try(HttpRequest.verifyUri(Uri(uri))).isSuccess,
-      s"Invalid downloadUrl, must be a valid URI"
+      uri => Try(HttpRequest.verifyUri(Uri(uri))).isSuccess || uri.startsWith("data:"),
+      s"Invalid downloadUrl, must be a valid http(s): or data: URL"
     )
 
   final val checksumValidator: Validate[String] =

--- a/build.sbt
+++ b/build.sbt
@@ -16,10 +16,11 @@ lazy val scoverageSettings = {
 
 lazy val compileDeps = Seq(
   ws,
-  "uk.gov.hmrc"   %% "bootstrap-backend-play-28" % "5.1.0",
-  "uk.gov.hmrc"   %% "auth-client"               % "5.6.0-play-28",
-  "com.kenshoo"   %% "metrics-play"              % "2.7.3_0.8.2",
-  "org.typelevel" %% "cats-core"                 % "2.6.0"
+  "uk.gov.hmrc"        %% "bootstrap-backend-play-28" % "5.1.0",
+  "uk.gov.hmrc"        %% "auth-client"               % "5.6.0-play-28",
+  "com.kenshoo"        %% "metrics-play"              % "2.7.3_0.8.2",
+  "org.typelevel"      %% "cats-core"                 % "2.6.0",
+  "com.github.robtimus" % "data-url"                  % "2.0"
 )
 
 def testDeps(scope: String) =

--- a/it/uk/gov/hmrc/traderservices/controllers/FileTransferControllerISpec.scala
+++ b/it/uk/gov/hmrc/traderservices/controllers/FileTransferControllerISpec.scala
@@ -58,6 +58,16 @@ class FileTransferControllerISpec extends ServerBaseISpec with AuthStubs with Fi
       testFileTransferSuccess("test⫐1.jpeg", "Route1")
       testFileTransferSuccess("test2.txt", "Route1")
 
+      testDataTransferSuccess("oneByteArray", "Route1", Some(oneByteArray))
+      testDataTransferSuccess("twoBytesArray", "Route1", Some(twoBytesArray))
+      testDataTransferSuccess("threeBytesArray", "Route1", Some(threeBytesArray))
+      testDataTransferSuccess("prod.routes", "Route1")
+      testDataTransferSuccess("app.routes", "Route1")
+      testDataTransferSuccess("schema.json", "Route1")
+      testDataTransferSuccess("logback.xml", "Route1")
+      testDataTransferSuccess("test⫐1.jpeg", "Route1")
+      testDataTransferSuccess("test2.txt", "Route1")
+
       testFileTransferSuccess("oneByteArray", "NDRC", Some(oneByteArray))
       testFileTransferSuccess("twoBytesArray", "NDRC", Some(twoBytesArray))
       testFileTransferSuccess("threeBytesArray", "NDRC", Some(threeBytesArray))
@@ -159,6 +169,37 @@ class FileTransferControllerISpec extends ServerBaseISpec with AuthStubs with Fi
       result.status shouldBe 202
       verifyAuthorisationHasHappened()
       verifyFileDownloadHasHappened(fileName, 1)
+      verifyFileUploadHasHappened(1)
+    }
+  }
+
+  def testDataTransferSuccess(fileName: String, applicationName: String, bytesOpt: Option[Array[Byte]] = None) {
+    s"return 202 when transferring data as $fileName for #$applicationName succeeds" in new FileTransferTest(
+      fileName,
+      bytesOpt
+    ) {
+      givenAuthorised()
+      val fileUrl =
+        givenFileTransferSucceeds(
+          "Risk-123",
+          applicationName,
+          fileName,
+          bytes,
+          base64Content,
+          checksum,
+          fileSize,
+          xmlMetadataHeader
+        )
+
+      val result = wsClient
+        .url(s"$url/transfer-file")
+        .withHttpHeaders("x-correlation-id" -> correlationId)
+        .post(Json.parse(jsonDataPayload("Risk-123", applicationName)))
+        .futureValue
+
+      result.status shouldBe 202
+      verifyAuthorisationHasHappened()
+      verifyFileDownloadHaveNotHappen()
       verifyFileUploadHasHappened(1)
     }
   }

--- a/it/uk/gov/hmrc/traderservices/stubs/FileTransferStubs.scala
+++ b/it/uk/gov/hmrc/traderservices/stubs/FileTransferStubs.scala
@@ -329,6 +329,21 @@ trait FileTransferStubs {
          |"batchSize": 1,
          |"batchCount": 1
          |}""".stripMargin
+
+    def jsonDataPayload(caseReferenceNumber: String, applicationName: String) =
+      s"""{
+         |"conversationId":"$conversationId",
+         |"caseReferenceNumber":"$caseReferenceNumber",
+         |"applicationName":"$applicationName",
+         |"upscanReference":"XYZ0123456789",
+         |"downloadUrl":"data:image/jpeg;base64,$base64Content",
+         |"fileName":"$fileName",
+         |"fileMimeType":"image/jpeg",
+         |"fileSize": ${bytes.length},
+         |"checksum":"$checksum",
+         |"batchSize": 1,
+         |"batchCount": 1
+         |}""".stripMargin
   }
 
   private val chunkSize: Int = 2400

--- a/it/uk/gov/hmrc/traderservices/stubs/MultiFileTransferStubs.scala
+++ b/it/uk/gov/hmrc/traderservices/stubs/MultiFileTransferStubs.scala
@@ -334,6 +334,25 @@ trait MultiFileTransferStubs extends FileTransferStubs {
         .map(callbackUrl => s"""
          |,"callbackUrl":"$wireMockBaseUrlAsString$callbackUrl"""".stripMargin)
         .getOrElse("")}}""".stripMargin
+
+    def jsonDataPayload(caseReferenceNumber: String, applicationName: String, callbackUrlOpt: Option[String]) =
+      s"""{
+         |"conversationId":"$conversationId",
+         |"caseReferenceNumber":"$caseReferenceNumber",
+         |"applicationName":"$applicationName",
+         |"files":[{
+         |  "upscanReference":"XYZ0123456789",
+         |  "downloadUrl":"data:image/jpeg;base64,$base64Content",
+         |  "fileName":"$fileName",
+         |  "fileMimeType":"image/jpeg",
+         |  "fileSize": ${bytes.length},
+         |  "checksum":"$checksum"
+         |}],
+         |"metadata":{"foo":{"bar":1},"zoo":"zar"}
+         |${callbackUrlOpt
+        .map(callbackUrl => s"""
+         |,"callbackUrl":"$wireMockBaseUrlAsString$callbackUrl"""".stripMargin)
+        .getOrElse("")}}""".stripMargin
   }
 
   case class TestFileTransfer(

--- a/test/uk/gov/hmrc/traderservices/models/FileTransferRequestValidationSpec.scala
+++ b/test/uk/gov/hmrc/traderservices/models/FileTransferRequestValidationSpec.scala
@@ -76,6 +76,12 @@ class FileTransferRequestValidationSpec extends UnitSpec {
         .validate(validRequest.copy(downloadUrl = "foo.jpg"))
         .isValid shouldBe true
       FileTransferRequest
+        .validate(validRequest.copy(downloadUrl = "http://foo.bar/baz/foo.jpg"))
+        .isValid shouldBe true
+      FileTransferRequest
+        .validate(validRequest.copy(downloadUrl = "data:text/plain;charset=UTF-8,hello"))
+        .isValid shouldBe true
+      FileTransferRequest
         .validate(validRequest.copy(downloadUrl = "foo:bar"))
         .isValid shouldBe false
       FileTransferRequest
@@ -131,6 +137,12 @@ class FileTransferRequestValidationSpec extends UnitSpec {
       FileTransferData
         .validate(validData.copy(downloadUrl = ""))
         .isValid shouldBe false
+      FileTransferData
+        .validate(validData.copy(downloadUrl = "http://foo.bar/baz/foo.jpg"))
+        .isValid shouldBe true
+      FileTransferData
+        .validate(validData.copy(downloadUrl = "data:text/plain;charset=UTF-8,hello"))
+        .isValid shouldBe true
       FileTransferData
         .validate(validData.copy(downloadUrl = "foo.jpg"))
         .isValid shouldBe true


### PR DESCRIPTION
This PR adds support for data: URL schema as per [RFC 2397](https://datatracker.ietf.org/doc/html/rfc2397). This will subsequently enable us to implement the new feature of sending user input as a document seamlessly.